### PR TITLE
`#492.1` attempt

### DIFF
--- a/crates/aiken-project/src/github/repo.rs
+++ b/crates/aiken-project/src/github/repo.rs
@@ -1,22 +1,112 @@
-use reqwest::{blocking::Client, header::USER_AGENT, Error};
+use reqwest::{
+    blocking::{Client, Response},
+    header::USER_AGENT,
+    Error,
+};
 use serde::Deserialize;
 
+enum Get {
+    LatestRelease,
+    Releases,
+    Tags,
+    Branches,
+    MainBranch,
+}
+
+// #region Github repo's RELEASES
 #[derive(Deserialize)]
-pub struct LatestRelease {
+pub struct Release {
     pub tag_name: String,
 }
 
+pub struct LatestRelease {}
 impl LatestRelease {
-    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Self, Error> {
-        Ok({
-            Client::new()
-                .get(format!(
-                    "https://api.github.com/repos/{}/releases/latest",
-                    repo.as_ref()
-                ))
-                .header(USER_AGENT, "aiken")
-                .send()?
-                .json::<Self>()?
-        })
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Release, Error> {
+        http_get(repo, Get::LatestRelease)?.json::<Release>()
     }
+}
+
+pub struct Releases {}
+impl Releases {
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Vec<Release>, Error> {
+        http_get(repo, Get::Releases)?.json::<Vec<Release>>()
+    }
+}
+// #endregion
+
+// #region Github repo's TAGS
+#[derive(Deserialize)]
+pub struct Tag {
+    pub name: String,
+}
+pub struct Tags {}
+impl Tags {
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Vec<Tag>, Error> {
+        http_get(repo, Get::Tags)?.json::<Vec<Tag>>()
+    }
+}
+// #endregion
+
+// #region Github repo's BRANCHES
+#[derive(Deserialize)]
+pub struct Branch {
+    pub name: String,
+}
+
+pub struct MainBranch {}
+impl MainBranch {
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Branch, Error> {
+        http_get(repo, Get::MainBranch)?.json::<Branch>()
+    }
+}
+
+pub struct Branches {}
+impl Branches {
+    pub fn of<Repo: AsRef<str>>(repo: Repo) -> Result<Vec<Branch>, Error> {
+        http_get(repo, Get::Branches)?.json::<Vec<Branch>>()
+    }
+}
+// #endregion
+
+pub fn default_version_of<Repo: AsRef<str>>(repo: Repo) -> Option<String> {
+    if let Ok(release) = LatestRelease::of(&repo) {
+        return Some(release.tag_name);
+    }
+
+    if let Ok(releases) = Releases::of(&repo) {
+        if let Some(release) = releases.first() {
+            return Some(release.tag_name.clone());
+        }
+    }
+
+    if let Ok(branch) = MainBranch::of(&repo) {
+        return Some(branch.name);
+    }
+
+    if let Ok(branches) = Branches::of(&repo) {
+        if let Some(branch) = branches.first() {
+            return Some(branch.name.clone());
+        }
+    }
+
+    if let Ok(tags) = Tags::of(&repo) {
+        if let Some(tag) = tags.first() {
+            return Some(tag.name.clone());
+        }
+    }
+
+    None
+}
+
+fn http_get<Repo: AsRef<str>>(repo: Repo, get: Get) -> Result<Response, Error> {
+    let mut url = format!("https://api.github.com/repos/{}/", repo.as_ref());
+    url.push_str(match get {
+        Get::LatestRelease => "releases/latest",
+        Get::Releases => "releases",
+        Get::Tags => "tags",
+        Get::Branches => "branches",
+        Get::MainBranch => "branches/master", // Github will try to redirect this to main
+    });
+
+    Client::new().get(url).header(USER_AGENT, "aiken").send()
 }

--- a/crates/aiken/src/cmd/packages/upgrade.rs
+++ b/crates/aiken/src/cmd/packages/upgrade.rs
@@ -1,6 +1,7 @@
 use super::add;
 
 #[derive(clap::Args)]
+#[clap(disable_version_flag = true)]
 /// Change the version of an installed dependency
 pub struct Args {
     /// Package name, in the form of {owner}/{repository}.
@@ -12,7 +13,7 @@ pub struct Args {
     package: String,
     /// The package version, as a git commit hash, a tag or a branch name.
     #[clap(long)]
-    version: String,
+    version: Option<String>,
 }
 
 pub fn exec(args: Args) -> miette::Result<()> {


### PR DESCRIPTION
An attempt to do #492 point 1:
- [x] The `--version` option on `aiken add` could be made optional; when not provided, the dependency will be added considering only the default branch

`aiken add <PACKAGES>`:
| Initial Condition | Add Packages | Result |
| ----------------- | ------------ | ------ |
| aiken.toml: ![1a - initial condition](https://github.com/ariady-putra/aiken/assets/2069784/492c2cb6-3b5e-4347-bfc7-9fe709dc2513) | `aiken add`: ![1b - add packages](https://github.com/ariady-putra/aiken/assets/2069784/f219b9a9-6fdf-45a0-81b8-62866fbeb6d5) | aiken.toml: ![1c - result](https://github.com/ariady-putra/aiken/assets/2069784/20dcb726-fd51-43e3-b439-99b727dab10a) |

When no `--version` provided, it will try to get the package version with the following order:
↳ `LatestRelease` - if no non pre-release version, then ↴
↳ `Releases[0]` - if no release available, then ↴
↳ `MainBranch` - if for some reason no branch named `master` or `main`, then ↴
↳ `Branches[0]` - should be available, but for the sake of completeness ↴
↳ `Tags[0]` - if everything fails, then version will be `main`

Since `packages upgrade` command calls the `add` command with `overwrite: true`, so
`aiken packages upgrade <PACKAGE>`:
| Initial Versions | Upgrade Packages | Result |
| ---------------- | ---------------- | ------ |
| aiken.toml: ![2a - old versions](https://github.com/ariady-putra/aiken/assets/2069784/df563e93-267c-483e-b564-33c3906d2a89) | `aiken packages upgrade`: ![2b - upgrade packages](https://github.com/ariady-putra/aiken/assets/2069784/d6da94b8-8d22-4a6b-ad65-0e546a9a5e3c) | aiken.toml: ![2c - result](https://github.com/ariady-putra/aiken/assets/2069784/ade44a5f-9ecf-405b-9319-db4244c2bd9c) |
